### PR TITLE
Add go dot env extension

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 CEPH_METRICS_RGW_HOST="https://your-ceph-rgw-endpoint-here"
-CEPH_METRICS_RGW_USER="your-rgw-admin-user-here"
-CEPH_METRICS_RGW_PASSWORD="your-rgw-admin-password-here"
+CEPH_METRICS_RGW_ACCESS_KEY="your-rgw-admin-access-key-here"
+CEPH_METRICS_RGW_SECRET_KEY="your-rgw-admin-secret-key-here"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,10 +9,7 @@
             "type": "go",
             "request": "launch",
             "mode": "auto",
-            "program": "${workspaceFolder}",
-            // Be sure to create an actual `.env` based on the `.env.example` in the
-            // root of the project
-            "envFile": "${workspaceFolder}/.env"
+            "program": "${workspaceFolder}"
         }
     ]
 }

--- a/charts/extended-ceph-exporter/README.md
+++ b/charts/extended-ceph-exporter/README.md
@@ -19,8 +19,8 @@ To install the chart with the release name `my-release`:
 helm install my-release extended-ceph-exporter/extended-ceph-exporter \
 --set config.rgw.accessKey=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c10) \
 --set config.rgw.secretKey=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c10) \
---set config.rgw.host=https://your-ceph-rgw-endpoint-here
--namespace <your-cluster-namespace>
+--set config.rgw.host=https://your-ceph-rgw-endpoint-here \
+--namespace <your-cluster-namespace>
 ```
 
 or update `values.yaml` before running:

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/joho/godotenv v1.4.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/joho/godotenv v1.4.0 h1:3l4+N6zfMWnkbPEXKng2o2/MR5mSwTrBih4ZEkkz1lg=
+github.com/joho/godotenv v1.4.0/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/ceph/go-ceph/rgw/admin"
+	"github.com/joho/godotenv"
 	"github.com/koor-tech/extended-ceph-exporter/collector"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -82,6 +83,8 @@ func flagNameFromEnvName(s string) string {
 }
 
 func parseFlagsAndEnvVars() error {
+	godotenv.Load(".env")
+
 	for _, v := range os.Environ() {
 		vals := strings.SplitN(v, "=", 2)
 


### PR DESCRIPTION
And fix .env.example.

The previous code relied on vscode to load the .env file, but running `go run .` directly would fail because the environment variables are not read. This PR adds the library [godotenv](https://github.com/joho/godotenv), which reads the .env file.