### PR TITLE
helm: fix helm rgw host template issue

### DIFF
--- a/charts/extended-ceph-exporter/Chart.yaml
+++ b/charts/extended-ceph-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.1
+version: 1.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/extended-ceph-exporter/README.md
+++ b/charts/extended-ceph-exporter/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying the extended-ceph-exporter to Kubernetes
 
-![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.2](https://img.shields.io/badge/AppVersion-v1.0.2-informational?style=flat-square)
+![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.2](https://img.shields.io/badge/AppVersion-v1.0.2-informational?style=flat-square)
 
 ## Get Repo Info
 

--- a/charts/extended-ceph-exporter/templates/_helpers.tpl
+++ b/charts/extended-ceph-exporter/templates/_helpers.tpl
@@ -66,10 +66,10 @@ RGW Host value
 */}}
 {{- define "extended-ceph-exporter.rgwHost" -}}
 {{- with .Values.config.rgw.host }}
-{{- .Values.config.rgw.host }}
+{{- $.Values.config.rgw.host }}
 {{- else }}
 {{- range (lookup "ceph.rook.io/v1" "CephObjectStore" "" "").items }}
-{{- .status.info.endpoint}}
+{{- .status.info.endpoint }}
 {{- break }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Alexander Trost <galexrt@googlemail.com>

This fixes the install issue:

```console
Release "extended-ceph-exporter" does not exist. Installing it now.
Error: template: extended-ceph-exporter/templates/secrets.yaml:8:28: executing "extended-ceph-exporter/templates/secrets.yaml" at <include "extended-ceph-exporter.rgwHost" .>: error calling include: template: extended-ceph-exporter/templates/_helpers.tpl:69:11: executing "extended-ceph-exporter.rgwHost" at <.Values.config.rgw.host>: can't evaluate field Values in type string
```

Caused by the `{{ with ... }}` statement as it changes the `.` variable.