### PR TITLE
helm: correctly select first cephobjectstore for rgw host

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ below list all existing collectors and the required Ceph components.
 * Golang 1.19
 * Depending on the module requirements, a Ceph cluster with the respective Ceph components.
 
+### Making Changes to the Helm Chart
+
+When changing anything in the Helm Chart, the version in the `Chart.yaml` needs to be increased according to [Semver](https://semver.org/).
+Additionally `make helm-doc` must be run afterwards and the changes to the Helm Chart's `README.md` must be commited as well.
+
 ### Debugging
 
 A VSCode debug config is available to run and debug the project.

--- a/charts/extended-ceph-exporter/Chart.yaml
+++ b/charts/extended-ceph-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.3
+version: 1.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/extended-ceph-exporter/README.md
+++ b/charts/extended-ceph-exporter/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying the extended-ceph-exporter to Kubernetes
 
-![Version: 1.2.3](https://img.shields.io/badge/Version-1.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.2](https://img.shields.io/badge/AppVersion-v1.0.2-informational?style=flat-square)
+![Version: 1.2.4](https://img.shields.io/badge/Version-1.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.2](https://img.shields.io/badge/AppVersion-v1.0.2-informational?style=flat-square)
 
 ## Get Repo Info
 

--- a/charts/extended-ceph-exporter/templates/_helpers.tpl
+++ b/charts/extended-ceph-exporter/templates/_helpers.tpl
@@ -68,9 +68,9 @@ RGW Host value
 {{- with .Values.config.rgw.host }}
 {{- $.Values.config.rgw.host }}
 {{- else }}
-{{- range (lookup "ceph.rook.io/v1" "CephObjectStore" "" "").items }}
-{{- .status.info.endpoint }}
-{{- break }}
+{{- $cephobjs := (lookup "ceph.rook.io/v1" "CephObjectStore" "" "").items }}
+{{- with $cephobjs }}
+{{- (first $cephobjs).status.info.endpoint }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Resolves #24

***

There is no break for go template loops so we take the list of cephobjectstore objects and take the first one if it isn't empty (e.g., when no object stores exist of it is a `--dry-run`).