### PR TITLE
helm: create artifacthub-repo.yml

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,17 @@
+# Artifact Hub repository metadata file
+#
+# Some settings like the verified publisher flag or the ignored packages won't
+# be applied until the next time the repository is processed. Please keep in
+# mind that the repository won't be processed if it has not changed since the
+# last time it was processed. Depending on the repository kind, this is checked
+# in a different way. For Helm http based repositories, we consider it has
+# changed if the `index.yaml` file changes. For git based repositories, it does
+# when the hash of the last commit in the branch you set up changes. This does
+# NOT apply to ownership claim operations, which are processed immediately.
+#
+repositoryID: 3f878ede-bafd-49bd-9272-6a8b820cc15a
+owners: # (optional, used to claim repository ownership)
+  - name: zuhairkoor
+    email: zuhair@koor.tech
+  - name: galexrt
+    email: alexander@koor.tech


### PR DESCRIPTION
This is used to add a verified publisher label to artifacthub

See: https://artifacthub.io/docs/topics/repositories/#verified-publisher