### PR TITLE
helm: add option to use an existing secret for rgw credentials

### DIFF
--- a/charts/extended-ceph-exporter/Chart.yaml
+++ b/charts/extended-ceph-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.8
+version: 1.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/extended-ceph-exporter/README.md
+++ b/charts/extended-ceph-exporter/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying the extended-ceph-exporter to Kubernetes
 
-![Version: 1.2.8](https://img.shields.io/badge/Version-1.2.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.2](https://img.shields.io/badge/AppVersion-v1.0.2-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.2](https://img.shields.io/badge/AppVersion-v1.0.2-informational?style=flat-square)
 
 ## Get Repo Info
 
@@ -56,6 +56,10 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 | affinity | object | `{}` | [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
 | autoscaling | object | `{"enabled":false,"maxReplicas":100,"minReplicas":1,"targetCPUUtilizationPercentage":80}` | Autoscaling configuration |
 | config.rgw.accessKey | string | Randomly generated | RGW admin access key |
+| config.rgw.existingSecret | object | `{"keys":{"access":"access","secret":"secret"},"name":""}` | Existing RGW admin credentials secret config |
+| config.rgw.existingSecret.keys.access | string | `"access"` | Access key secret key name |
+| config.rgw.existingSecret.keys.secret | string | `"secret"` | Secret key secret key name |
+| config.rgw.existingSecret.name | string | `""` | Name of the existing RGW admin credentials secret |
 | config.rgw.host | string | First detected RGW endpoint | The Ceph RGW endpoint as a URL, e.g. "https://your-ceph-rgw-endpoint-here:8443" |
 | config.rgw.secretKey | string | Randomly generated | RGW admin secret key |
 | fullnameOverride | string | `""` | Override fully-qualified app name |

--- a/charts/extended-ceph-exporter/templates/deployment.yaml
+++ b/charts/extended-ceph-exporter/templates/deployment.yaml
@@ -37,6 +37,19 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ include "extended-ceph-exporter.fullname" . }}
+          {{- if .Values.config.rgw.existingSecret.name }}
+          env:
+            - name: CEPH_METRICS_RGW_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.rgw.existingSecret.name | quote }}
+                  key: {{ .Values.config.rgw.existingSecret.keys.access | quote }}
+            - name: CEPH_METRICS_RGW_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.rgw.existingSecret.name | quote }}
+                  key: {{ .Values.config.rgw.existingSecret.keys.secret | quote }}
+          {{- end }}
           ports:
             - name: http-metrics
               containerPort: 9138

--- a/charts/extended-ceph-exporter/templates/post-install-job.yaml
+++ b/charts/extended-ceph-exporter/templates/post-install-job.yaml
@@ -89,18 +89,28 @@ spec:
             - name: CEPH_METRICS_RGW_HOST
               valueFrom:
                 secretKeyRef:
-                 name: {{ include "extended-ceph-exporter.fullname" . }}
-                 key: CEPH_METRICS_RGW_HOST
+                  name: {{ include "extended-ceph-exporter.fullname" . }}
+                  key: CEPH_METRICS_RGW_HOST
             - name: RGW_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                 name: {{ include "extended-ceph-exporter.fullname" . }}
-                 key: CEPH_METRICS_RGW_ACCESS_KEY
+                {{- if .Values.config.rgw.existingSecret.name }}
+                  name: {{ .Values.config.rgw.existingSecret.name | quote }}
+                  key: {{ .Values.config.rgw.existingSecret.keys.access | quote }}
+                {{ else }}
+                  name: {{ include "extended-ceph-exporter.fullname" . }}
+                  key: CEPH_METRICS_RGW_ACCESS_KEY
+                {{- end }}
             - name: RGW_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                 name: {{ include "extended-ceph-exporter.fullname" . }}
-                 key: CEPH_METRICS_RGW_SECRET_KEY
+                {{- if .Values.config.rgw.existingSecret.name }}
+                  name: {{ .Values.config.rgw.existingSecret.name | quote }}
+                  key: {{ .Values.config.rgw.existingSecret.keys.secret | quote }}
+                {{ else }}
+                  name: {{ include "extended-ceph-exporter.fullname" . }}
+                  key: CEPH_METRICS_RGW_SECRET_KEY
+                {{- end }}
           command:
             - /bin/bash
             - -c

--- a/charts/extended-ceph-exporter/templates/secrets.yaml
+++ b/charts/extended-ceph-exporter/templates/secrets.yaml
@@ -6,8 +6,10 @@ metadata:
     {{- include "extended-ceph-exporter.labels" . | nindent 4 }}
 data:
   CEPH_METRICS_RGW_HOST: {{ include "extended-ceph-exporter.rgwHost" . | b64enc }}
+{{- if not .Values.config.rgw.existingSecret.name }}
   CEPH_METRICS_RGW_ACCESS_KEY: {{ .Values.config.rgw.accessKey | default (randAlphaNum 20) | b64enc }}
   CEPH_METRICS_RGW_SECRET_KEY: {{ .Values.config.rgw.secretKey | default (randAlphaNum 40) | b64enc }}
+{{- end }}
 {{- range $k, $v := .Values.additionalEnv }}
   {{ $k }}: {{ $v | b64enc }}
 {{- end }}

--- a/charts/extended-ceph-exporter/values.yaml
+++ b/charts/extended-ceph-exporter/values.yaml
@@ -114,6 +114,15 @@ config:
     # -- The Ceph RGW endpoint as a URL, e.g. "https://your-ceph-rgw-endpoint-here:8443"
     # @default -- First detected RGW endpoint
     host: ""
+    # -- Existing RGW admin credentials secret config
+    existingSecret:
+      # -- Name of the existing RGW admin credentials secret
+      name: ""
+      keys:
+        # -- Access key secret key name
+        access: "access"
+        # -- Secret key secret key name
+        secret: "secret"
     # -- RGW admin access key
     # @default -- Randomly generated
     accessKey: null


### PR DESCRIPTION
Resolves #53

~~Still needs to be tested.~~ Ran a local test in my cluster and seems to work as expected to use the existing secret when given. The exporter was restarted because of the helm upgrade and used the new credentials as expected.