### PR TITLE
helm: make scrape timeout configurable

### DIFF
--- a/charts/extended-ceph-exporter/Chart.yaml
+++ b/charts/extended-ceph-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.1
+version: 1.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/extended-ceph-exporter/README.md
+++ b/charts/extended-ceph-exporter/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying the extended-ceph-exporter to Kubernetes
 
-![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.3](https://img.shields.io/badge/AppVersion-v1.0.3-informational?style=flat-square)
+![Version: 1.3.2](https://img.shields.io/badge/Version-1.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.3](https://img.shields.io/badge/AppVersion-v1.0.3-informational?style=flat-square)
 
 ## Get Repo Info
 

--- a/charts/extended-ceph-exporter/README.md
+++ b/charts/extended-ceph-exporter/README.md
@@ -84,4 +84,5 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 | serviceMonitor.enabled | bool | `false` | Specifies whether a prometheus-operator ServiceMonitor should be created |
 | serviceMonitor.namespaceSelector | string | `nil` |  |
 | serviceMonitor.scrapeInterval | duration | `"30s"` | Interval at which metrics should be scraped |
+| serviceMonitor.scrapeTimeout | duration | `"20s"` | Timeout for scraping |
 | tolerations | list | `[]` | [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |

--- a/charts/extended-ceph-exporter/templates/servicemonitor.yaml
+++ b/charts/extended-ceph-exporter/templates/servicemonitor.yaml
@@ -15,6 +15,7 @@ spec:
   endpoints:
     - port: http-metrics
       interval: {{ .Values.serviceMonitor.scrapeInterval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
     {{- if .Values.serviceMonitor.honorLabels }}
       honorLabels: true
     {{- end }}

--- a/charts/extended-ceph-exporter/values.yaml
+++ b/charts/extended-ceph-exporter/values.yaml
@@ -94,6 +94,8 @@ serviceMonitor:
   #   any: true
   # -- (duration) Interval at which metrics should be scraped
   scrapeInterval: 30s
+  # -- (duration) Timeout for scraping
+  scrapeTimeout: 20s
   # honorLabels: true
 
 prometheusRule:


### PR DESCRIPTION
This MR makes the scrape timeout of the `ServiceMonitor` generated by the Helm chart configurable. This is helpful to fix scrape timeouts if the extended-ceph-exporter needs more time to export metrics than the global timeout settings on a cluster.

The MR also introduces a default timeout of 20s in the `values.yaml` of the Helm chart. I mainly introduced the default to be consistent with the existing `scrapeTimeout` Helm parameter that also defines a default. I'd be happy to remove the default if you prefer.